### PR TITLE
fix python errors with disk_types

### DIFF
--- a/pyvmdk/pyvmdk.c
+++ b/pyvmdk/pyvmdk.c
@@ -546,6 +546,12 @@ PyMODINIT_FUNC initpyvmdk(
 	{
 		goto on_error;
 	}
+
+	if( pyvmdk_disk_types_init_type(
+	     &pyvmdk_disk_types_type_object) < 0 )
+	{
+		goto on_error;
+	}
 	Py_IncRef(
 	 (PyObject *) &pyvmdk_disk_types_type_object );
 
@@ -594,6 +600,12 @@ PyMODINIT_FUNC initpyvmdk(
 
 	if( PyType_Ready(
 	     &pyvmdk_extent_types_type_object ) < 0 )
+	{
+		goto on_error;
+	}
+
+	if( pyvmdk_extent_types_init_type(
+	     &pyvmdk_extent_types_type_object) < 0 )
 	{
 		goto on_error;
 	}

--- a/pyvmdk/pyvmdk_disk_types.c
+++ b/pyvmdk/pyvmdk_disk_types.c
@@ -153,7 +153,7 @@ int pyvmdk_disk_types_init_type(
 #endif
 	if( PyDict_SetItemString(
 	     type_object->tp_dict,
-	     "2GB_EXTENT_FLAT",
+	     "TWO_GB_EXTENT_FLAT",
 	     value_object ) != 0 )
 	{
 		goto on_error;
@@ -167,7 +167,7 @@ int pyvmdk_disk_types_init_type(
 #endif
 	if( PyDict_SetItemString(
 	     type_object->tp_dict,
-	     "2GB_EXTENT_SPARSE",
+	     "TWO_GB_EXTENT_SPARSE",
 	     value_object ) != 0 )
 	{
 		goto on_error;


### PR DESCRIPTION
add call to pyvmdk_disk_types_init_type and pyvmdk_extent_types_init_type
change names that start with a digit